### PR TITLE
feat: Add initial script setup

### DIFF
--- a/commit
+++ b/commit
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Check if ollama is installed
+if ! command -v ollama &>/dev/null; then
+    echo "ollama is not installed, please go to https://ollama.com and follow the instructions"
+    exit 1
+fi
+
+# Check if the current directory is a git repository
+if ! git rev-parse --is-inside-work-tree &>/dev/null; then
+    echo "Not a git repository"
+    exit 1
+fi
+
+diff=$(git diff --cached)
+
+# Check if there are changes to commit
+if [ -z "$diff" ]; then
+    echo "No changes to commit. Make sure you add the changes to the staging area before running this command."
+    exit 1
+fi
+
+prompt='''
+You are a seasoned developer, writing your commit message. 
+You must convey the following commit message format:
+
+<type>([scope]): <description>
+
+[optional body]
+
+With <type> being one of the following:
+[ 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test' ]
+
+Whith scope being an field that is used to specify the module that the commit is related to.
+
+With <description> being a short and concise description of the changes made.
+
+With [optional body] being a more detailed description of the changes made. If it is used, it must be separated from the description by a empty line.
+
+You must create a concise and descriptive commit message based on the following diff:
+
+'$diff'
+
+Only answer with the commit message as plain text and do not describe your reasoning.
+If there are a lot of changes, you are allowed to use bullet points as description body.
+
+- DO NOT LIE.
+- DO NOT HALLUCINATE. 
+- DO NOT ADD ANY NUMBERS OR SPECIAL CHARACTERS.
+- DO NOT ADD A FULL STOP AT THE END.
+'''
+
+# Run the prompt
+commit_message=$(ollama run llama3 "$prompt")
+
+echo "$commit_message"
+
+echo "\n----------------------------------------"
+
+read -p "Are you satisfied with this commit? (Y/N): " confirm
+
+# Check if the user is satisfied with the commit message
+if [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]]; then
+    git commit -m "$commit_message"
+    echo "Commit successful"
+else
+    echo "Commit aborted"
+fi

--- a/setup
+++ b/setup
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Check if the shell configuration file is passed
+if [ "$1" ]; then
+    input=true
+
+    shell_name=$(basename $1)
+else
+    input=false
+
+    # Check what kind of shell is being used
+    if [ -z "$SHELL" ]; then
+        echo "Shell not found"
+        exit 1
+    fi
+
+    # Extract the shell name from the provided shell path
+    shell_name=$(basename $SHELL)
+fi
+
+echo "Using shell: $shell_name \n"
+
+if [[ -z $(find $HOME -maxdepth 1 -type f -name ".$shell_name"rc) ]]; then
+    str="Shell configuration based on your "
+    if [ "$input" = true ]; then
+        str="$str input "
+    else
+        str=$str' $SHELL variable '
+    fi
+    str="$str not found."
+    echo $str
+    echo "You will need to pass your shell configuration file to the script."
+    exit 1
+else
+    echo "Shell configuration file found"
+    rc_path=$(find $HOME -maxdepth 1 -type f -name ".$shell_name"rc)
+fi
+
+# Check if commit alias is defined in the shell configuration file already
+if ! grep -q "alias commit=" $rc_path; then
+    echo -e "\n'commit alias' not found in the shell configuration file."
+    echo "Adding the commit alias to the shell configuration file"
+    echo "alias commit='sh $PWD/commit'" >>$rc_path
+else
+    echo -e "\n'commit alias' found in the shell configuration file."
+    echo "Overwriting the commit alias."
+    sed -i '' "s#alias commit=.*#alias commit='sh $PWD/commit'#" $rc_path
+fi
+
+echo -e "\nPlease run \033[0;31msource $rc_path\033[0m to apply the changes"
+echo "You can then use the 'commit' alias to run the commit script"


### PR DESCRIPTION
This PR contains the initial AI generated commit message script. Having a

* **Setup-Script** that sets an alias in the rc-File of the used (or specified) shell
* **Commit-Script** that is where the magic happens, using Ollama to generate a commit message while conveying to conventional commits.